### PR TITLE
add prod auth config

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -39,7 +39,8 @@ jobs:
           no-fail-on-empty-changeset: "1"
           parameter-overrides: >-
             Environment=prod
-
+      - name: Copy prod_auth_config.json
+        run: cp src/prod_auth_config.json src/auth_config.json
       - name: Install NPM Dependencies
         run: npm install
 

--- a/src/prod_auth_config.json
+++ b/src/prod_auth_config.json
@@ -1,0 +1,4 @@
+{
+  "domain": "faithforgeacademy.us.auth0.com",
+  "clientId": "O4lAeW8s6eybxneux67DljfI6fInB17R"
+}


### PR DESCRIPTION
This should, in theory, setup prod auth so logins are possible on app.faithforge.academy (currently they aren't working because that subdomain is not approved for the beta Auth0 application, nor should it be)