### PR TITLE
Fix speech recognition with phrases

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -7,8 +7,10 @@ import axios from "axios";
 import { useDispatch } from "react-redux";
 import { close } from '../features/openSlice';
 import { setGlobalVerse } from '../features/verseSlice.js';
+import { setGlobalWordCollection } from "../features/wordCollectionSlice.js";
 import { Button } from "reactstrap";
-
+import createWordsCollection from '../utils/appUtils.js';
+import {setGlobalPhrase} from '../features/phraseSlice.js';
 
 const Search = (props) => {
   const dispatch = useDispatch();
@@ -54,7 +56,10 @@ const Search = (props) => {
   }
 
   const handleVerse = (verse) => {
+    let scriptureWordCollection = createWordsCollection(verse.content);
     dispatch(setGlobalVerse(verse));
+    dispatch(setGlobalWordCollection(scriptureWordCollection));
+    dispatch(setGlobalPhrase(1));
     setVerse(verse);
     dispatch(close())
   }

--- a/src/features/phraseSlice.js
+++ b/src/features/phraseSlice.js
@@ -1,0 +1,16 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = 1;
+
+const phraseSlice = createSlice({
+  name: 'phrase',
+  initialState,
+  reducers: {
+    setGlobalPhrase(state, action) {
+      return parseInt(action.payload);
+    },
+  },
+});
+
+export const { setGlobalPhrase } = phraseSlice.actions;
+export default phraseSlice.reducer;

--- a/src/features/wordCollectionSlice.js
+++ b/src/features/wordCollectionSlice.js
@@ -1,0 +1,20 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = [];
+
+const wordCollectionSlice = createSlice({
+  name: 'wordCollection',
+  initialState,
+  reducers: {
+    setGlobalWordCollection(state, action) {
+      return [...action.payload];
+    },
+
+    setWordCollectionInstance(state, action) {
+      state[action.payload.idx] = action.payload;
+    }
+  },
+});
+
+export const { setGlobalWordCollection, setWordCollectionInstance } = wordCollectionSlice.actions;
+export default wordCollectionSlice.reducer;

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,11 +1,13 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import openReducer from './features/openSlice';
 import verseReducer from './features/verseSlice';
+import phraseReducer from './features/phraseSlice';
 
 
 const rootReducer = combineReducers({
   open: openReducer,
   verse: verseReducer,
+  phrase: phraseReducer
 });
 
 export default rootReducer;

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -2,12 +2,14 @@ import { combineReducers } from '@reduxjs/toolkit';
 import openReducer from './features/openSlice';
 import verseReducer from './features/verseSlice';
 import phraseReducer from './features/phraseSlice';
+import wordCollectionReducer from './features/wordCollectionSlice';
 
 
 const rootReducer = combineReducers({
   open: openReducer,
   verse: verseReducer,
-  phrase: phraseReducer
+  phrase: phraseReducer,
+  wordCollection: wordCollectionReducer
 });
 
 export default rootReducer;

--- a/src/utils/appUtils.js
+++ b/src/utils/appUtils.js
@@ -1,0 +1,41 @@
+/**
+ * This function takes a string of scripture text and splits it on a space.
+ * It then loops through each word creating an object:
+ *      If the "word" ends with punctuation, increment the phrase counter and add phrase to the object
+ *      Add an index to the object
+ *      Initialize "said" and "correct" both to boolean false
+ *      add the word to a "word" property
+ * 
+ * @param {string} scriptureText
+ * 
+ * returns an array of word objects 
+ */
+function createWordsCollection(scriptureText) {
+    let scriptureSimpleWordArray = scriptureText.split(/\s+/);
+    let scriptureWordsCollection = [];
+    let currentWord;
+    let currentWordObject;
+    let currentPhrase = 1;
+
+    for (let i=0; i < scriptureSimpleWordArray.length; i++) {
+        currentWord = scriptureSimpleWordArray[i];
+        currentWordObject = {};
+
+        currentWordObject.idx = i;
+        currentWordObject.word = currentWord;
+        currentWordObject.said = false;
+        currentWordObject.correct = null;
+
+        currentWordObject.phrase = currentPhrase;
+        
+        if (currentWord.match(/[.,/#!$%^&*;:{}=\-_`~()]/gu)) {
+            currentPhrase++
+        }
+
+        scriptureWordsCollection.push(currentWordObject)
+    }
+
+    return scriptureWordsCollection;
+}
+
+export default createWordsCollection;

--- a/src/views/Study.js
+++ b/src/views/Study.js
@@ -14,6 +14,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { useSelector, useDispatch } from "react-redux";
 import {setGlobalPhrase} from '../features/phraseSlice.js';
+import { Mic, MicOff, Check } from "lucide-react"
 
 // Mock scripture data (replace with actual data in a real application)
 const scripture = {
@@ -105,21 +106,39 @@ function createWordsCollection(scriptureText) {
 
 export default function Study() {
     const dispatch = useDispatch();
+    const {
+        finalTranscript,
+        listening,
+        resetTranscript,
+    } = useSpeechRecognition();
   
-  const v = useSelector((state) => { return state.verse});
+    const v = useSelector((state) => { return state.verse});
   
-  if (v !== {} && v.id !== undefined && v.content !== undefined){
-    scripture.reference = v.id;
-    scripture.text = v.content;
-  } else if (window.localStorage.getItem("verse")){
-    const v = JSON.parse(window.localStorage.getItem("verse"))
-    scripture.reference = v.id;
-    scripture.text = v.content;
-  }
+    if (v !== {} && v.id !== undefined && v.content !== undefined){
+        scripture.reference = v.id;
+        scripture.text = v.content;
+    } else if (window.localStorage.getItem("verse")){
+        const v = JSON.parse(window.localStorage.getItem("verse"))
+        scripture.reference = v.id;
+        scripture.text = v.content;
+    }
 
+    scripture.replacedText = stripPunctuation(scripture.text)
+    scripture.splitText = scripture.replacedText.split(/\s+/)
+    const [activeTab, setActiveTab] = useState(0)
+    const [spokenText, setSpokenText] = useState("")
+    let [currentWordIndex, setCurrentWordIndex] = useState(0)
     let [wordCounter, setWordCounter] = useState(0)
+    const [testSubmission, setTestSubmission] = useState("")
+    const [testResult, setTestResult] = useState([])
     let [phraseIndex, setPhraseIndex] = useState(useSelector((state) => {return state.phrase}));
     let scriptureWordCollection = createWordsCollection(scripture.text);
+    let phraseCount = scriptureWordCollection[scriptureWordCollection.length - 1].phrase;
+    let phraseNums = [];
+
+    for (let i = 1; i <= phraseCount; i++) {
+      phraseNums.push(i);
+    }
 
     useEffect(() => {
 

--- a/src/views/Study.js
+++ b/src/views/Study.js
@@ -16,6 +16,7 @@ import { useSelector, useDispatch } from "react-redux";
 import {setGlobalPhrase} from '../features/phraseSlice.js';
 import { Mic, MicOff, Check } from "lucide-react"
 import { setGlobalWordCollection, setWordCollectionInstance } from "../features/wordCollectionSlice.js";
+import createWordsCollection from '../utils/appUtils.js';
 
 // Mock scripture data (replace with actual data in a real application)
 const scripture = {
@@ -65,46 +66,6 @@ function a11yProps(index) {
     };
 }
 
-/**
- * This function takes a string of scripture text and splits it on a space.
- * It then loops through each word creating an object:
- *      If the "word" ends with punctuation, increment the phrase counter and add phrase to the object
- *      Add an index to the object
- *      Initialize "said" and "correct" both to boolean false
- *      add the word to a "word" property
- * 
- * @param {string} scriptureText
- * 
- * returns an array of word objects 
- */
-function createWordsCollection(scriptureText) {
-    let scriptureSimpleWordArray = scriptureText.split(/\s+/);
-    let scriptureWordsCollection = [];
-    let currentWord;
-    let currentWordObject;
-    let currentPhrase = 1;
-
-    for (let i=0; i < scriptureSimpleWordArray.length; i++) {
-        currentWord = scriptureSimpleWordArray[i];
-        currentWordObject = {};
-
-        currentWordObject.idx = i;
-        currentWordObject.word = currentWord;
-        currentWordObject.said = false;
-        currentWordObject.correct = null;
-
-        currentWordObject.phrase = currentPhrase;
-        
-        if (currentWord.match(/[.,/#!$%^&*;:{}=\-_`~()]/gu)) {
-            currentPhrase++
-        }
-
-        scriptureWordsCollection.push(currentWordObject)
-    }
-
-    return scriptureWordsCollection;
-}
-
 export default function Study() {
     const dispatch = useDispatch();
     const {
@@ -127,7 +88,7 @@ export default function Study() {
     scripture.replacedText = stripPunctuation(scripture.text)
     scripture.splitText = scripture.replacedText.split(/\s+/)
     const [activeTab, setActiveTab] = useState(0)
-    const [spokenText, setSpokenText] = useState("")
+    const [spokenText, setSpokenText] = useState(useSelector((state) => { return state.verse}))
     let [currentWordIndex, setCurrentWordIndex] = useState(0)
     let [wordCounter, setWordCounter] = useState(0)
     const [testSubmission, setTestSubmission] = useState("")

--- a/src/views/Study.js
+++ b/src/views/Study.js
@@ -24,7 +24,7 @@ const scripture = {
 }
 
 // Simple word-by-word comparison function
-function compareWords(original: string, spoken: string): { correct: boolean; word: string }[] {
+function compareWords(original, spoken) {
   const originalWords = original.split(/\s+/)
   const spokenWords = spoken.toLowerCase().split(/\s+/)
   return originalWords.map((word, index) => ({
@@ -67,8 +67,9 @@ export default function Study() {
     listening,
     resetTranscript,
   } = useSpeechRecognition();
+  
   const v = useSelector((state) => { return state.verse});
-  console.log(v);
+  
   if (v !== {} && v.id !== undefined && v.content !== undefined){
     scripture.reference = v.id;
     scripture.text = v.content;
@@ -85,34 +86,52 @@ export default function Study() {
   const [currentWordIndex, setCurrentWordIndex] = useState(0)
   const [testSubmission, setTestSubmission] = useState("")
   const [testResult, setTestResult] = useState([])
+  const [allSpoken, setAllSpoken] = useState("")
+  const [scripturePhrases, setScripturePhrases] = useState([])
+  const [phraseIndex, setPhraseIndex] = useState(0)
 
   useEffect(() => {
 
         if (activeTab === 1) {
           console.log("spokenText:", spokenText)
           let transSplits = []
+          let increase = 0
+
+          setScripturePhrases(scripture.text.split(/[.,/#!$%^&*;:{}=\-_`~()]/gu))
+
           if(spokenText !== ""){
             transSplits = spokenText.trim().split(/\s+/)
+
+            if (spokenText.toLocaleLowerCase == scripturePhrases[phraseIndex].toLocaleLowerCase) {
+              setPhraseIndex(phraseIndex + 1)
+            }
           }
           console.log("splits:", transSplits)
-          if (transSplits.length === 0 && currentWordIndex !== 0){
-            console.log("paused... after matching")
+          
+          //if (transSplits.length === 0 && currentWordIndex !== 0){
+          //  console.log("paused... after matching")
             //startSpeechRecognition()
-            return
-          }
-          let increase = 0
+          //  return
+          //}
+        
           console.log(currentWordIndex)
-          for (let i in transSplits){
+          
+          for (let i in transSplits) {
             const curr = transSplits[i].toLowerCase()
             const currentWord = scripture.splitText[currentWordIndex + increase].toLowerCase()
+            
             console.log(curr, currentWord, currentWordIndex, curr === currentWord)
+            
             if (curr === currentWord){
               increase++
+              setAllSpoken(allSpoken + ` ${currentWord}`)
+              
             } else {
               console.log("hmmm...")
               break
             }
           }
+
           if(increase !== 0){
             console.log("increasing currentWordIndex by "+ increase)
             setCurrentWordIndex(prev => Math.min(prev + increase, scripture.splitText.length - 1))
@@ -145,7 +164,7 @@ export default function Study() {
       SpeechRecognition.stopListening()
     } else {
       console.log("toggleListening: false")
-      SpeechRecognition.startListening()
+      SpeechRecognition.startListening({continuous: true})
     }
   }
 
@@ -195,8 +214,12 @@ export default function Study() {
                     <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>
                 </div>
+                <div>
+                  {allSpoken}
+                </div>
                 <div className="text-center text-2xl font-bold p-4 border rounded">
-                  {scripture.text.split(/\s+/)[currentWordIndex]}
+                  {/*scripture.text.split(/\s+/)[currentWordIndex]*/}
+                  {scripturePhrases[phraseIndex]}
                 </div>
                 <Button onClick={toggleListening} variant="outline" className="w-full">
                   {listening ? <MicOff className="mr-2 h-4 w-4" /> : <Mic className="mr-2 h-4 w-4" />}

--- a/src/views/Study.js
+++ b/src/views/Study.js
@@ -25,40 +25,42 @@ const scripture = {
 
 // Simple word-by-word comparison function
 function compareWords(original, spoken) {
-  const originalWords = original.split(/\s+/)
-  const spokenWords = spoken.toLowerCase().split(/\s+/)
-  return originalWords.map((word, index) => ({
-    correct: index < spokenWords.length && replaceText(word) === replaceText(spokenWords[index]),
-    word: word
-  }))
+    const originalWords = original.split(/\s+/)
+    const spokenWords = spoken.toLowerCase().split(/\s+/)
+    
+    return originalWords.map((word, index) => ({
+        correct: index < spokenWords.length && stripPunctuation(word) === stripPunctuation(spokenWords[index]),
+        word: word
+    }))
 }
 
-function replaceText(str){
-  str = str.replaceAll(/[.,/#!$%^&*;:{}=\-_`~()]/gu, '').toLowerCase()
-  return str
+function stripPunctuation(str){
+    str = str.replaceAll(/[.,/#!$%^&*;:{}=\-_`~()]/gu, '').toLowerCase()
+    
+    return str
 }
 
 function CustomTabPanel(props) {
-  const { children, value, index, ...other } = props;
+    const { children, value, index, ...other } = props;
 
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`simple-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}
-      {...other}
-    >
-      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
-    </div>
+    return (
+        <div
+            role="tabpanel"
+            hidden={value !== index}
+            id={`simple-tabpanel-${index}`}
+            aria-labelledby={`simple-tab-${index}`}
+            {...other}
+        >
+            {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+        </div>
   );
 }
 
 function a11yProps(index) {
-  return {
-    id: `simple-tab-${index}`,
-    'aria-controls': `simple-tabpanel-${index}`,
-  };
+    return {
+        id: `simple-tab-${index}`,
+        'aria-controls': `simple-tabpanel-${index}`,
+    };
 }
 
 /**
@@ -179,12 +181,20 @@ export default function Study() {
         }
   }, [activeTab, spokenText, currentWordIndex, resetTranscript])
 
+  /**
+   * This useEffect watches for when the active tab changes value and resets
+   * spoken text, test result, and test submission
+   */
   useEffect(() => {
     setSpokenText("")
     setTestResult([])
     setTestSubmission("")
   }, [activeTab])
 
+  /**
+   * This useEffect watches for a change in the finalTranscript variable and
+   * sets the spokenText state to the final transcript value
+   */
   useEffect(() => {
     setSpokenText(finalTranscript)
   }, [finalTranscript])

--- a/src/views/Study.js
+++ b/src/views/Study.js
@@ -38,7 +38,7 @@ function compareWords(original, spoken) {
 }
 
 function stripPunctuation(str){
-    str = str.replaceAll(/[.,/#!$%^&*;:{}=\-_`~()]/gu, '').toLowerCase()
+    str = str.replaceAll(/[^\w\s]+/gu, '').toLowerCase()
     
     return str
 }
@@ -120,7 +120,8 @@ export default function Study() {
             let scriptureWordInstance;
 
             if(spokenText !== ""){
-                transSplits = spokenText.trim().split(/\s+/)
+                let cleanspokenText = stripPunctuation(spokenText);
+                transSplits = cleanspokenText.trim().split(/\s+/)
             }
 
             for (let i in transSplits) {
@@ -136,7 +137,7 @@ export default function Study() {
                   nextPhrase = nextWord.phrase;
                 }
 
-                // console.log(curr, currentWord, wordCounter, curr === currentWord)
+                console.log(curr, currentWord, wordCounter, curr === currentWord)
                 
                 if (curr === currentWord){
                     scriptureWordInstance.said = true;

--- a/src/views/Study.js
+++ b/src/views/Study.js
@@ -61,6 +61,46 @@ function a11yProps(index) {
   };
 }
 
+/**
+ * This function takes a string of scripture text and splits it on a space.
+ * It then loops through each word creating an object:
+ *      If the "word" ends with punctuation, increment the phrase counter and add phrase to the object
+ *      Add an index to the object
+ *      Initialize "said" and "correct" both to boolean false
+ *      add the word to a "word" property
+ * 
+ * @param {string} scriptureText
+ * 
+ * returns an array of word objects 
+ */
+function createWordsCollection(scriptureText) {
+    let scriptureSimpleWordArray = scriptureText.split(/\s+/);
+    let scriptureWordsCollection = [];
+    let currentWord;
+    let currentWordObject;
+    let currentPhrase = 1;
+
+    for (let i=0; i < scriptureSimpleWordArray.length; i++) {
+        currentWord = scriptureSimpleWordArray[i];
+        currentWordObject = {};
+
+        currentWordObject.idx = i;
+        currentWordObject.word = currentWord;
+        currentWordObject.said = false;
+        currentWordObject.correct = null;
+
+        currentWordObject.phrase = currentPhrase;
+        
+        if (currentWord.match(/[.,/#!$%^&*;:{}=\-_`~()]/gu)) {
+            currentPhrase++
+        }
+
+        scriptureWordsCollection.push(currentWordObject)
+    }
+
+    return scriptureWordsCollection;
+}
+
 export default function Study() {
   const {
     finalTranscript,
@@ -79,16 +119,7 @@ export default function Study() {
     scripture.text = v.content;
   }
 
-  scripture.replacedText = replaceText(scripture.text)
-  scripture.splitText = scripture.replacedText.split(/\s+/)
-  const [activeTab, setActiveTab] = useState(0)
-  const [spokenText, setSpokenText] = useState("")
-  const [currentWordIndex, setCurrentWordIndex] = useState(0)
-  const [testSubmission, setTestSubmission] = useState("")
-  const [testResult, setTestResult] = useState([])
-  const [allSpoken, setAllSpoken] = useState("")
-  const [scripturePhrases, setScripturePhrases] = useState([])
-  const [phraseIndex, setPhraseIndex] = useState(0)
+    let scriptureWordCollection = createWordsCollection(scripture.text);
 
   useEffect(() => {
 

--- a/src/views/Study.js
+++ b/src/views/Study.js
@@ -216,14 +216,6 @@ export default function Study() {
     setTestResult(compareWords(scripture.text, testSubmission))
   }
 
-  const nextWord = () => {
-    setCurrentWordIndex(prev => Math.min(prev + 1, scripture.text.split(/\s+/).length - 1))
-  }
-
-  const prevWord = () => {
-    setCurrentWordIndex(prev => Math.max(prev - 1, 0))
-  }
-
   const handleTabChange = (e, newValue) => {
     setActiveTab(newValue);
   }

--- a/src/views/Study.js
+++ b/src/views/Study.js
@@ -15,6 +15,7 @@ import Typography from '@mui/material/Typography';
 import { useSelector, useDispatch } from "react-redux";
 import {setGlobalPhrase} from '../features/phraseSlice.js';
 import { Mic, MicOff, Check } from "lucide-react"
+import { setGlobalWordCollection, setWordCollectionInstance } from "../features/wordCollectionSlice.js";
 
 // Mock scripture data (replace with actual data in a real application)
 const scripture = {
@@ -131,8 +132,14 @@ export default function Study() {
     let [wordCounter, setWordCounter] = useState(0)
     const [testSubmission, setTestSubmission] = useState("")
     const [testResult, setTestResult] = useState([])
-    let [phraseIndex, setPhraseIndex] = useState(useSelector((state) => {return state.phrase}));
-    let scriptureWordCollection = createWordsCollection(scripture.text);
+    let [phraseIndex, setPhraseIndex] = useState(useSelector((state) => {return state.phrase}));    
+    let scriptureWordCollection = useSelector((state) => {return state.wordCollection});
+    
+    if (typeof scriptureWordCollection == 'object' && Array.isArray(scriptureWordCollection) && scriptureWordCollection.length == 0) {
+      scriptureWordCollection = createWordsCollection(scripture.text);
+      dispatch(setGlobalWordCollection(scriptureWordCollection));
+    }
+    
     let phraseCount = scriptureWordCollection[scriptureWordCollection.length - 1].phrase;
     let phraseNums = [];
 
@@ -149,6 +156,7 @@ export default function Study() {
             let transSplits = []
             let increase = 0
             let nextPhrase = 1;
+            let scriptureWordInstance;
 
             if(spokenText !== ""){
                 transSplits = spokenText.trim().split(/\s+/)
@@ -161,15 +169,16 @@ export default function Study() {
                 
                 let nextI = wordCounter + 1;
                 let nextWord = scriptureWordCollection[`${nextI}`];
+                scriptureWordInstance = {...scriptureWordCollection[wordCounter]};
 
                 if (typeof nextWord != 'undefined') {
                   nextPhrase = nextWord.phrase;
                 }
 
-                console.log(curr, currentWord, wordCounter, curr === currentWord)
+                // console.log(curr, currentWord, wordCounter, curr === currentWord)
                 
                 if (curr === currentWord){
-                    scriptureWordCollection[wordCounter].said = true;
+                    scriptureWordInstance.said = true;
 
                     dispatch(setGlobalPhrase(nextPhrase));
                     setPhraseIndex(nextPhrase);
@@ -188,6 +197,8 @@ export default function Study() {
                 if (parseInt(i) === transSplits.length - 1) {
                   setWordCounter(wordCounter++);
                 }
+
+                dispatch(setWordCollectionInstance(scriptureWordInstance));
             }
 
             if(increase !== 0){
@@ -201,7 +212,7 @@ export default function Study() {
             // Only update for final results in test mode
             setTestSubmission(spokenText)
         }
-  }, [activeTab, spokenText, currentWordIndex, resetTranscript, dispatch, scriptureWordCollection, wordCounter])
+  }, [activeTab, spokenText, currentWordIndex, resetTranscript, dispatch])
 
   /**
    * This useEffect watches for when the active tab changes value and resets

--- a/src/views/Study.js
+++ b/src/views/Study.js
@@ -228,6 +228,22 @@ export default function Study() {
     setActiveTab(newValue);
   }
 
+  function getPhrase(phraseIndex) {
+    const requestedPhrase = scriptureWordCollection.map((wordObj) =>
+      wordObj.phrase == phraseIndex ? <span
+        key={wordObj.idx}
+        style={{
+          color: (wordObj.said) ? '#00DD00' : '#CCCCCC',
+          paddingRight: '4px'
+        }}
+      >
+        {wordObj.word}
+      </span> : ""
+    );
+
+    return requestedPhrase;
+  }
+  
   return (
     <>
         <Tabs value={activeTab} onChange={handleTabChange}>
@@ -245,25 +261,15 @@ export default function Study() {
               <h1>Word-by-Word Practice</h1>
               <p>Practice the scripture word by word</p>
               <div className="space-y-4">
-                <div className="flex justify-between items-center">
-                  <Button onClick={prevWord} disabled={currentWordIndex === 0}>
-                    <ArrowLeft className="mr-2 h-4 w-4" />
-                    Previous
-                  </Button>
-                  <span className="text-sm text-muted-foreground">
-                    Word {currentWordIndex + 1} of {scripture.text.split(/\s+/).length}
-                  </span>
-                  <Button onClick={nextWord} disabled={currentWordIndex === scripture.text.split(/\s+/).length - 1}>
-                    Next
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  </Button>
-                </div>
-                <div>
-                  {allSpoken}
-                </div>
                 <div className="text-center text-2xl font-bold p-4 border rounded">
-                  {/*scripture.text.split(/\s+/)[currentWordIndex]*/}
-                  {scripturePhrases[phraseIndex]}
+                  {
+                    phraseNums.map((phraseNum) => 
+                      phraseNum <= phraseIndex ?
+                      <div>
+                        {getPhrase(phraseNum)}
+                      </div> : ""
+                    )
+                  }
                 </div>
                 <Button onClick={toggleListening} variant="outline" className="w-full">
                   {listening ? <MicOff className="mr-2 h-4 w-4" /> : <Mic className="mr-2 h-4 w-4" />}


### PR DESCRIPTION
This code changes the practice area to be phrase centric instead of going word by word. This PR should be regarded as a first step towards using phrasing in the practice mode. I stopped here to try to keep the scope in control. The changes made are:

- creation of a data structure representing the collection of words objects in the verse
- management of the word objects collection in redux
- management of current phrase in redux as well as the rendering of the verse.
- Update the stripPunctuation regex to be more robust (I was getting stuck on the word "doesn't". there are several unicode characters for a single quote)
- I switched the speech recognition to continuous to accomplish going phrase by phrase

For the time being, you have to manually stop listening in practice mode once you've practiced the text. A future TODO will be to stop listening programmatically when the user has spoken the last word in the last phrase. Another TODO will be better handling of the behavior when a user gets a word wrong, and possibly an addition of a reset button, BUT in it's current state, it seems to be in an MVP working state